### PR TITLE
Add AI whiteboard scaffold

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Rename this file to .env and provide your OpenAI API key
+OPENAI_API_KEY=

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+.env
+/dist

--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
-# tldraw
+# AI Whiteboard Prototype
+
+This is a scaffold project integrating [tldraw](https://tldraw.dev) with an AI assistant using the OpenAI GPT‑4.1 API. It uses React 18, Vite, and TypeScript.
+
+## Scripts
+
+- `npm run dev` – start the Vite dev server and API proxy
+- `npm run build` – build the client
+
+Create a `.env` file from `.env.example` with your `OPENAI_API_KEY` before running.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>AI Whiteboard Prototype</title>
+  </head>
+  <body class="h-screen">
+    <div id="root" class="h-full"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "ai-whiteboard-prototype",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev:client": "vite",
+    "dev:server": "nodemon src/server/chat.ts",
+    "dev": "concurrently \"npm:dev:server\" \"npm:dev:client\"",
+    "build": "vite build"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "tldraw": "^3.13.1",
+    "@tldraw/ai": "^0.0.18",
+    "openai": "^4.0.0",
+    "express": "^4.18.2"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.0",
+    "@types/react-dom": "^18.2.0",
+    "@vitejs/plugin-react": "^4.0.0",
+    "concurrently": "^8.0.0",
+    "nodemon": "^2.0.22",
+    "tailwindcss": "^3.3.0",
+    "postcss": "^8.4.21",
+    "autoprefixer": "^10.4.14",
+    "typescript": "^5.0.4",
+    "vite": "^4.4.0",
+    "tailwindcss-animate": "^1.0.0"
+  }
+}

--- a/postcss.config.cjs
+++ b/postcss.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,17 @@
+import React, { useState } from 'react';
+import TldrawWrapper from './components/TldrawWrapper';
+import ChatSidebar from './components/ChatSidebar';
+
+export default function App() {
+  const [editor, setEditor] = useState<any>(null);
+  return (
+    <div className="flex h-full">
+      <div className="flex-1">
+        <TldrawWrapper onEditorReady={setEditor} />
+      </div>
+      <div className="w-80 border-l">
+        <ChatSidebar editor={editor} />
+      </div>
+    </div>
+  );
+}

--- a/src/components/ChatSidebar.tsx
+++ b/src/components/ChatSidebar.tsx
@@ -1,0 +1,93 @@
+import React, { useState, useEffect, useRef } from 'react';
+import { Button } from './ui/button';
+import { Input } from './ui/input';
+
+interface ChatMessage {
+  role: 'user' | 'assistant';
+  content: string;
+}
+
+interface Props {
+  editor: any;
+}
+
+export default function ChatSidebar({ editor }: Props) {
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [input, setInput] = useState('');
+  const endRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    endRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [messages]);
+
+  const sendMessage = async () => {
+    if (!input.trim()) return;
+    const userMsg: ChatMessage = { role: 'user', content: input };
+    setMessages((m) => [...m, userMsg]);
+    setInput('');
+
+    const payload = {
+      prompt: input,
+      canvas: {},
+    };
+
+    const res = await fetch('/api/chat', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+
+    const reader = res.body?.getReader();
+    if (!reader) return;
+    const decoder = new TextDecoder();
+    let done = false;
+    let assistant: ChatMessage = { role: 'assistant', content: '' };
+    setMessages((m) => [...m, assistant]);
+
+    while (!done) {
+      const { value, done: doneReading } = await reader.read();
+      done = doneReading;
+      if (value) {
+        const chunk = decoder.decode(value);
+        assistant = { ...assistant, content: assistant.content + chunk };
+        setMessages((m) => {
+          const arr = [...m];
+          arr[arr.length - 1] = assistant;
+          return arr;
+        });
+      }
+    }
+  };
+
+  const onKey = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter') sendMessage();
+  };
+
+  return (
+    <div className="flex flex-col h-full">
+      <div className="flex-1 overflow-y-auto p-2 space-y-2">
+        {messages.map((m, i) => (
+          <div
+            key={i}
+            className={`text-sm p-2 rounded ${
+              m.role === 'user' ? 'bg-blue-100 ml-auto' : 'bg-gray-100'
+            }`}
+          >
+            {m.content}
+          </div>
+        ))}
+        <div ref={endRef} />
+      </div>
+      <div className="p-2 border-t flex space-x-2">
+        <Input
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          onKeyDown={onKey}
+          placeholder="Ask the AI"
+          className="flex-1"
+        />
+        <Button onClick={sendMessage}>Send</Button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/TldrawWrapper.tsx
+++ b/src/components/TldrawWrapper.tsx
@@ -1,0 +1,41 @@
+import React, { useRef, useCallback } from 'react';
+import { Tldraw, TLShape, TLUiOverrides } from 'tldraw';
+import 'tldraw/tldraw.css';
+
+interface Props {
+  onEditorReady?: (editor: any) => void;
+}
+
+export default function TldrawWrapper({ onEditorReady }: Props) {
+  const editorRef = useRef<any>(null);
+
+  const handleMount = useCallback((editor: any) => {
+    editorRef.current = editor;
+    onEditorReady?.(editor);
+  }, [onEditorReady]);
+
+  const toolsOverride: TLUiOverrides = {
+    tools(editor, tools) {
+      const { select, draw, geo, text } = tools;
+      return {
+        select,
+        draw,
+        geo,
+        text,
+      };
+    },
+  };
+
+  return (
+    <div className="w-full h-full">
+      <Tldraw
+        persistenceKey="ai-demo"
+        overrides={toolsOverride}
+        getShapeVisibility={(shape: TLShape) =>
+          (shape as any).meta?.hidden ? 'hidden' : 'inherit'
+        }
+        onMount={handleMount}
+      />
+    </div>
+  );
+}

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+interface Props extends React.ButtonHTMLAttributes<HTMLButtonElement> {}
+
+export const Button = React.forwardRef<HTMLButtonElement, Props>((props, ref) => (
+  <button
+    ref={ref}
+    {...props}
+    className={`px-3 py-1 rounded border bg-white hover:bg-gray-50 disabled:opacity-50 ${props.className || ''}`}
+  />
+));
+Button.displayName = 'Button';

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+interface Props extends React.InputHTMLAttributes<HTMLInputElement> {}
+
+export const Input = React.forwardRef<HTMLInputElement, Props>((props, ref) => (
+  <input
+    ref={ref}
+    {...props}
+    className={`border px-2 py-1 rounded focus:outline-none focus:ring w-full ${props.className || ''}`}
+  />
+));
+Input.displayName = 'Input';

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './styles.css';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/src/server/chat.ts
+++ b/src/server/chat.ts
@@ -1,0 +1,79 @@
+import express from 'express';
+import { Configuration, OpenAIApi } from 'openai';
+import * as dotenv from 'dotenv';
+
+dotenv.config();
+
+export const app = express();
+app.use(express.json({ limit: '1mb' }));
+
+const openai = new OpenAIApi(new Configuration({ apiKey: process.env.OPENAI_API_KEY }));
+
+app.post('/api/chat', async (req, res) => {
+  const { prompt, canvas } = req.body;
+
+  const messages = [
+    { role: 'system', content: 'You are a canvas assistant.' },
+    { role: 'assistant', content: `Canvas state: ${JSON.stringify(canvas)}` },
+    { role: 'user', content: prompt },
+  ];
+
+  const functions = [
+    {
+      name: 'applyTldrawChanges',
+      description: 'Apply changes to the canvas.',
+      parameters: {
+        type: 'object',
+        properties: {
+          shapes: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                action: { type: 'string' },
+                data: { type: 'object' },
+              },
+              required: ['action', 'data'],
+            },
+          },
+        },
+      },
+    },
+  ];
+
+  try {
+    res.setHeader('Content-Type', 'text/event-stream');
+    res.setHeader('Cache-Control', 'no-cache');
+
+    const completion = await openai.createChatCompletion(
+      {
+        model: 'gpt-4.1',
+        messages,
+        functions,
+        function_call: 'auto',
+        stream: true,
+      },
+      { responseType: 'stream' }
+    );
+
+    completion.data.on('data', (chunk: Buffer) => {
+      const payload = chunk.toString();
+      if (payload.trim()) res.write(payload);
+    });
+
+    completion.data.on('end', () => {
+      res.write('data: [DONE]\n\n');
+      res.end();
+    });
+  } catch (err) {
+    console.error(err);
+    res.status(500).end();
+  }
+});
+
+if (require.main === module) {
+  const PORT = process.env.PORT || 3000;
+  app.listen(PORT, () => {
+    console.log(`Server listening on http://localhost:${PORT}`);
+  });
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/src/utils/aiClient.ts
+++ b/src/utils/aiClient.ts
@@ -1,0 +1,8 @@
+export async function chat(payload: any) {
+  const res = await fetch('/api/chat', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+  return res;
+}

--- a/src/utils/tldrawUtils.ts
+++ b/src/utils/tldrawUtils.ts
@@ -1,0 +1,8 @@
+export function serializeCanvas(editor: any) {
+  if (!editor) return {};
+  return editor.store.serialize();
+}
+
+export function validatePatches(_patches: any) {
+  return true;
+}

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -1,0 +1,10 @@
+module.exports = {
+  content: [
+    './index.html',
+    './src/**/*.{ts,tsx}'
+  ],
+  theme: {
+    extend: {}
+  },
+  plugins: [require('tailwindcss-animate')]
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "useDefineForClassFields": true,
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noFallthroughCasesInSwitch": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["src/server"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    proxy: {
+      '/api': 'http://localhost:3000'
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- set up Vite + React + TypeScript scaffold
- integrate tldraw and basic chat sidebar
- add Express server proxy for OpenAI GPT‑4.1 API
- configure Tailwind and shadcn-style UI components

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685564ebc334833380aa6dd799e5daf2